### PR TITLE
More minor tweaks to the UI

### DIFF
--- a/bin/flight-cache
+++ b/bin/flight-cache
@@ -38,5 +38,7 @@ require 'bundler/setup'
 
 require 'flight_cache_cli'
 
+Dir.chdir(ENV.fetch('FLIGHT_CWD','.'))
+
 FlightCacheCli.run! if $PROGRAM_NAME == __FILE__
 

--- a/lib/flight_cache_cli.rb
+++ b/lib/flight_cache_cli.rb
@@ -48,7 +48,7 @@ class FlightCacheCli
   extend Commander::Delegates
 
   program :name,        'flight-cache'
-  program :version,     '0.6.0'
+  program :version,     '0.6.1'
   program :description, 'Manages the flight file cache'
   program :help_paging, false
 

--- a/lib/flight_cache_cli.rb
+++ b/lib/flight_cache_cli.rb
@@ -188,6 +188,10 @@ class FlightCacheCli
     scope_option(c)
     act(c) do |tag, filepath, name = nil, opts|
       name ||= File.basename(filepath)
+      raise <<~ERROR.gsub("\n", ' ').chomp if name == '-'
+        The file name must not be a hypen. Please provide the second FILENAME
+        argument if uploading from stdin
+      ERROR
       io = (filepath == '-' ? $stdin : File.open(filepath, 'r'))
       blob = cache.upload(name, io, tag: tag, scope: opts[:scope])
       puts "File '#{blob.filename}' has been uploaded. Size: #{blob.size}B"


### PR DESCRIPTION
To prevent issues using `flexec`, there needs to be a way to change the working directory after the ruby process has started. This is done using an environment variable `FLIGHT_CWD` and fixes #18 

Also files can no longer be uploaded if they are called `-`. This is to prevent issues with downloading to stdout. Fixes #17 